### PR TITLE
Update scripts to use python3

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -149,7 +149,7 @@ skript nebo příkaz ručně:
 # Skript automaticky ukončí předchozí Flask
 bash start_flask.sh
 # nebo ručně
-source venv/bin/activate && python main.py
+source venv/bin/activate && python3 main.py
 ```
 
 Po načtení aliasů stačí příkaz:

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ new helper script or manually:
 # automatically stops any previous Flask instance
 bash start_flask.sh
 # or manually
-source venv/bin/activate && python main.py
+source venv/bin/activate && python3 main.py
 # or using the alias
 jarvik-flask
 ```
@@ -401,7 +401,7 @@ A minimal configuration might look like:
 Generate the `password_hash` value with:
 
 ```bash
-python -c "import auth; print(auth.hash_password('your_password'))"
+python3 -c "import auth; print(auth.hash_password('your_password'))"
 ```
 
 ### Adding users via helper script
@@ -412,13 +412,13 @@ the helper as a module from the repository root so Python can locate
 `auth.py`:
 
 ```bash
-python -m tools.create_user --nick bob --password pw
+python3 -m tools.create_user --nick bob --password pw
 ```
 
 For example, to create a user `alice` with password `SecretPass123` run:
 
 ```bash
-python -m tools.create_user --nick alice --password SecretPass123
+python3 -m tools.create_user --nick alice --password SecretPass123
 ```
 
 The repository also includes a `users.example.json` file containing the same
@@ -478,7 +478,7 @@ helper reads the target URL from the `JARVIK_URL` environment variable or from a
 `devlab_config.json` file containing a `url` field.
 
 ```bash
-JARVIK_URL=http://example.com:8000 python -m tools.test_endpoint -m "ping"
+JARVIK_URL=http://example.com:8000 python3 -m tools.test_endpoint -m "ping"
 ```
 
 Example `devlab_config.json`:
@@ -490,7 +490,7 @@ Example `devlab_config.json`:
 With this file present you can simply run:
 
 ```bash
-python -m tools.test_endpoint --log flask.log
+python3 -m tools.test_endpoint --log flask.log
 ```
 
 The script prints the HTTP response and, when `--log` is given, shows the last

--- a/install_jarvik.sh
+++ b/install_jarvik.sh
@@ -29,7 +29,7 @@ fi
 # Create personal memory logs for users defined in users.json
 if [ -f users.json ]; then
   echo "📄 Vytvářím osobní paměti pro uživatele..."
-  python - <<'PY'
+  python3 - <<'PY'
 import json, os
 with open('users.json', 'r', encoding='utf-8') as f:
     data = json.load(f)
@@ -46,7 +46,7 @@ fi
 # Vytvoření virtuálního prostředí (pokud není)
 if [ ! -d venv ]; then
   echo "🧪 Vytvářím virtuální prostředí venv/..."
-  python -m venv venv
+  python3 -m venv venv
 fi
 
 # Aktivace venv a instalace požadavků

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -18,12 +18,12 @@ knowledge/
   vzdelavani/           # Education
 ```
 
-Only plain text files (`.txt`) are loaded. Convert any PDFs or DOCX documents before adding them here. Use `python convert_to_txt.py` from the repository root. The script relies on `pdfplumber` and `python-docx`, so install them manually if they are not present.
+Only plain text files (`.txt`) are loaded. Convert any PDFs or DOCX documents before adding them here. Use `python3 convert_to_txt.py` from the repository root. The script relies on `pdfplumber` and `python-docx`, so install them manually if they are not present.
 
 Recommended workflow for new material:
 
 1. Place PDFs or DOCX files in the `knowledge/` folder.
-2. Run `python convert_to_txt.py` to create text versions in `knowledge_txt/`.
+2. Run `python3 convert_to_txt.py` to create text versions in `knowledge_txt/`.
 3. Move the generated `.txt` files into the appropriate subfolder listed above.
 4. After verifying the text files, delete the original PDF/DOCX sources.
 

--- a/start_flask.sh
+++ b/start_flask.sh
@@ -43,7 +43,7 @@ fi
 
 # Spuštění Flasku
 # Např. FLASK_DEBUG=false bash start_flask.sh vypne debug mód
-python main.py > "$FLASK_LOG" 2>&1 &
+python3 main.py > "$FLASK_LOG" 2>&1 &
 FLASK_PID=$!
 echo $FLASK_PID > "$PID_FILE"
 wait $FLASK_PID

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -65,7 +65,7 @@ check_flask() {
       echo -e "${RED}❌ Chybí virtuální prostředí venv/.${NC}"
       return
     fi
-    nohup python main.py > flask.log 2>&1 &
+    nohup python3 main.py > flask.log 2>&1 &
   fi
 }
 


### PR DESCRIPTION
## Summary
- use `python3` for inline scripts and venv creation in install_jarvik.sh
- run Flask with `python3` in start_flask.sh and watchdog
- update docs to consistently call `python3`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870442a04a083279ad62eb3b8e1dc72