### PR TITLE
Update docs for Python 3 requirement

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -14,6 +14,8 @@ Výchozí umístění adresářů `memory/` a `knowledge/` lze změnit pomocí p
 
 ## Instalace
 
+Python 3 je nezbytný pro spuštění Jarvika. Ubuntu 25.04 obsahuje Python 3.12.
+
 1. Spusťte instalační skript, který vytvoří virtuální prostředí a nainstaluje závislosti:
    ```bash
    bash install_jarvik.sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ environment variable toggles Flask's debug mode and defaults to `true`.
 
 ## Installation
 
+Python 3 is required to run Jarvik. Ubuntu 25.04 already includes Python 3.12.
 Install dependencies and create the virtual environment:
 
 ```bash


### PR DESCRIPTION
## Summary
- state that Python 3 is required and note Ubuntu 25.04 ships with Python 3.12

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68709e04232c8327969a783e65118682