### PR TITLE
Fix answer download path sanitization

### DIFF
--- a/main.py
+++ b/main.py
@@ -897,10 +897,12 @@ def ask_file():
 @require_auth
 def download_answer(filename: str):
     """Serve generated answer files."""
-    path = os.path.join(ANSWER_DIR, filename)
-    if not os.path.exists(path):
+    safe_name = os.path.basename(filename)
+    path = os.path.abspath(os.path.join(ANSWER_DIR, safe_name))
+    base = os.path.abspath(ANSWER_DIR)
+    if os.path.commonpath([path, base]) != base or not os.path.exists(path):
         return jsonify({"error": "not found"}), 404
-    return send_file(path, as_attachment=True, download_name=filename)
+    return send_file(path, as_attachment=True, download_name=safe_name)
 
 @app.route("/memory/add", methods=["POST"])
 @require_auth

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -295,6 +295,21 @@ def test_ask_file_save_creates_file(client):
     assert "attachments" not in entry
 
 
+def test_answer_download_path_traversal(client):
+    # create a saved answer file
+    res = client.post(
+        "/ask_file",
+        data={"message": "path", "save": "1"},
+        headers=_auth(),
+    )
+    assert res.status_code == 200
+    fname = res.get_json()["download_url"].split("/")[-1]
+
+    # path traversal attempt should return 404
+    res = client.get(f"/answers/../{fname}", headers=_auth())
+    assert res.status_code == 404
+
+
 def test_per_user_knowledge_folders(client):
     import main
     client.get("/knowledge/search", query_string={"q": "hello"}, headers=_auth())


### PR DESCRIPTION
## Summary
- sanitize filenames for answer downloads
- validate download paths stay within the answer directory
- add regression test for path traversal attempts

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711ced6f688327833ee047dd397b62