### PR TITLE
Add helper for removing temporary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,22 @@ skript `switch_model.sh` se jménem požadovaného modelu:
 bash switch_model.sh mistral:7b-Q4_K_M
 ```
 
+### Cleaning temporary files
+
+Python may create `__pycache__` folders and `.pyc` files during normal
+execution. Remove these artifacts with the helper script:
+
+```bash
+bash clean_temp.sh
+```
+
+The script simply runs commands such as:
+
+```bash
+find . -name '__pycache__' -type d -exec rm -r {} +
+find . -name '*.pyc' -delete
+```
+
 ## Quick Start Script
 
 For a single command that activates the environment, loads the model and

--- a/clean_temp.sh
+++ b/clean_temp.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit
+
+# Remove Python cache folders and bytecode files
+echo "🧹 Removing temporary Python artifacts..."
+find . -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null
+find . -name '*.pyc' -delete
+
+echo "✅ Temporary files removed."


### PR DESCRIPTION
## Summary
- add `clean_temp.sh` script to wipe `__pycache__` and `.pyc`
- document how to clean temporary artifacts in `README.md`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68712799c738832794da0638442cc6a3