### PR TITLE
Add OpenRouter instructions

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -68,7 +68,22 @@ Podobné skripty jsou připraveny i pro další modely:
 bash start_llama3_8b.sh      # llama3:8b
 bash start_command_r.sh      # command-r
 bash start_nous_hermes2.sh   # nous-hermes2
-MODEL_NAME=api bash start_jarvik.sh # externí API
+MODEL_MODE=api bash start_jarvik.sh  # externí API
+```
+Pro službu OpenRouter nastavte proměnné například takto:
+
+```bash
+export MODEL_MODE=api
+export API_URL=https://api.openrouter.ai/v1/chat/completions
+export API_MODEL=meta-llama/llama-3-70b-instruct
+export API_KEY=sk-...
+jarvik-start
+```
+
+Návrat k lokálnímu modelu zajistí:
+
+```bash
+bash switch_model.sh llama3:8b
 ```
 Každý z těchto skriptů volá `switch_model.sh`,
 který nejprve zastaví běžící model i Flask a poté

--- a/README.md
+++ b/README.md
@@ -260,6 +260,25 @@ API_KEY=sk-... bash start_jarvik.sh
 The start script skips starting Ollama in this mode. The `/ask` endpoints will
 send requests to `API_URL` using the provided key (or an `X-API-Key` header).
 
+#### Using OpenRouter
+
+`MODEL_MODE=api` also works with third-party services such as OpenRouter. To
+try the LLaMA 3 70B model run:
+
+```bash
+export MODEL_MODE=api
+export API_URL=https://api.openrouter.ai/v1/chat/completions
+export API_MODEL=meta-llama/llama-3-70b-instruct
+export API_KEY=sk-...
+jarvik-start
+```
+
+Return to the local model with:
+
+```bash
+bash switch_model.sh llama3:8b
+```
+
 ## Checking Status
 
 See which services are running using:

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -20,6 +20,7 @@ MODEL_NAME=${MODEL_NAME:-"openchat"}
 # Log file for the model output
 MODEL_LOG="${MODEL_NAME//:/_}.log"
 # Allow API mode when MODEL_NAME or MODEL_MODE indicate so
+# MODEL_MODE=api works with services such as OpenRouter or OpenAI
 MODEL_MODE=${MODEL_MODE:-"local"}
 if [ "$MODEL_NAME" = "api" ]; then
   MODEL_MODE="api"


### PR DESCRIPTION
## Summary
- explain how to enable OpenRouter in README and manual
- mention OpenRouter as an API provider in `start_jarvik.sh`

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68720a3b78408327885b9833cb35d6cf