### PR TITLE
Add wrapper for LLAMA3 70B API

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ jarvik-start
 # LLaMA 3 8B model
 bash start_llama3_8b.sh
 
+# LLaMA 3 70B via API
+API_KEY=sk-... bash start_llama3_70b.sh
+
 # Command R model
 bash start_command_r.sh
 
@@ -264,6 +267,12 @@ MODEL_MODE=api \
 API_URL=https://api.openrouter.ai/v1/chat/completions \
 API_MODEL=meta-llama/llama-3-70b-instruct \
 API_KEY=sk-... bash start_jarvik.sh
+```
+
+Alternatively run the wrapper script with your API key:
+
+```bash
+API_KEY=sk-... bash start_llama3_70b.sh
 ```
 
 The start script skips starting Ollama in this mode. The `/ask` endpoints will

--- a/start_llama3_70b.sh
+++ b/start_llama3_70b.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+MODEL_MODE=api \
+API_URL=https://api.openrouter.ai/v1/chat/completions \
+API_MODEL=meta-llama/llama-3-70b-instruct \
+bash "$DIR/switch_model.sh" api "$@"
+


### PR DESCRIPTION
## Summary
- add `start_llama3_70b.sh` wrapper
- document LLAMA3 70B API script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68720ec1c3ec8327ac3e73d368ada799