### PR TITLE
Add jarvik-start-70b alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ bash load.sh
 
 This will append alias commands such as `jarvik-start`, `jarvik-status`,
 `jarvik-model`, `jarvik-flask`, `jarvik-ollama` and wrappers for the
-available models to your `~/.bashrc` and reload the file. The `jarvik-start`
-alias launches the default OpenChat model.
+available models (`jarvik-start-llama3`, `jarvik-start-70b`,
+`jarvik-start-command-r`, `jarvik-start-nh2`, `jarvik-start-api`) to your
+`~/.bashrc` and reload the file. The `jarvik-start` alias launches the default
+OpenChat model.
 
 ### Wiping old knowledge
 

--- a/load.sh
+++ b/load.sh
@@ -14,6 +14,7 @@ alias jarvik-model='bash $DIR/start_model.sh'
 alias jarvik-ollama='bash $DIR/start_ollama.sh'
 alias jarvik-start-nh2='bash $DIR/start_nous_hermes2.sh'
 alias jarvik-start-llama3='bash $DIR/start_llama3_8b.sh'
+alias jarvik-start-70b='bash $DIR/start_llama3_70b.sh'
 alias jarvik-start-command-r='bash $DIR/start_command_r.sh'
 alias jarvik-start-api='MODEL_NAME=api bash $DIR/start_jarvik.sh'
 


### PR DESCRIPTION
## Summary
- add `jarvik-start-70b` wrapper alias to `load.sh`
- document the new alias in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68721554ad288327a21ddfb8f847f938