### PR TITLE
Add OpenRouter API instructions

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -70,7 +70,11 @@ bash start_command_r.sh      # command-r
 bash start_nous_hermes2.sh   # nous-hermes2
 MODEL_MODE=api bash start_jarvik.sh  # externí API
 ```
-Pro službu OpenRouter nastavte proměnné například takto:
+
+### Using OpenRouter
+
+Proměnná `MODEL_MODE=api` zapne vzdálené API. Pro službu OpenRouter nastavte
+proměnné například takto:
 
 ```bash
 export MODEL_MODE=api

--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ send requests to `API_URL` using the provided key (or an `X-API-Key` header).
 
 #### Using OpenRouter
 
-`MODEL_MODE=api` also works with third-party services such as OpenRouter. To
-try the LLaMA 3 70B model run:
+Set `MODEL_MODE=api` to enable remote API calls. To try OpenRouter's LLaMA  3 70B model run:
 
 ```bash
 export MODEL_MODE=api

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -20,7 +20,8 @@ MODEL_NAME=${MODEL_NAME:-"openchat"}
 # Log file for the model output
 MODEL_LOG="${MODEL_NAME//:/_}.log"
 # Allow API mode when MODEL_NAME or MODEL_MODE indicate so
-# MODEL_MODE=api works with services such as OpenRouter or OpenAI
+# MODEL_MODE=api works with providers like OpenAI or OpenRouter
+# See README for an OpenRouter example
 MODEL_MODE=${MODEL_MODE:-"local"}
 if [ "$MODEL_NAME" = "api" ]; then
   MODEL_MODE="api"


### PR DESCRIPTION
## Summary
- clarify how to enable remote API calls
- document OpenRouter example in MANUAL and README
- note OpenRouter in start script comments

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68722b094d1c8327b330f67d2616da3f