### PR TITLE
Update API fallback example

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ API_MODEL=gpt-3.5-turbo \
 API_KEY=sk-... bash start_jarvik.sh
 ```
 
-To use OpenRouter as a remote fallback for the LLaMA 3 70B model run:
+For the LLaMA 3\u00a070B model you can use OpenRouter as a remote fallback:
 
 ```bash
 MODEL_MODE=api \


### PR DESCRIPTION
## Summary
- clarify example for using OpenRouter as a remote fallback in API mode

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6872581e051c8327a5e69c9b90c1776a