### PR TITLE
Add script for LLaMA3 70B API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ available models (`jarvik-start-llama3`, `jarvik-start-70b`,
 `jarvik-start-command-r`, `jarvik-start-nh2`, `jarvik-start-api`) to your
 `~/.bashrc` and reload the file. The `jarvik-start` alias launches the default
 OpenChat model.
+The `jarvik-start-70b` alias relies on the OpenRouter API, so make sure to set
+`API_KEY` with your personal key before using it.
 
 ### Wiping old knowledge
 
@@ -151,7 +153,7 @@ jarvik-start
 bash start_llama3_8b.sh
 
 # LLaMA 3 70B via API
-API_KEY=sk-... bash start_llama3_70b.sh
+API_KEY=sk-... bash start_llama3_70b.sh  # requires your OpenRouter key
 
 # Command R model
 bash start_command_r.sh
@@ -274,7 +276,7 @@ API_KEY=sk-... bash start_jarvik.sh
 Alternatively run the wrapper script with your API key:
 
 ```bash
-API_KEY=sk-... bash start_llama3_70b.sh
+API_KEY=sk-... bash start_llama3_70b.sh  # requires your OpenRouter key
 ```
 
 The start script skips starting Ollama in this mode. The `/ask` endpoints will

--- a/start_llama3_70b.sh
+++ b/start_llama3_70b.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 DIR="$(cd "$(dirname "$0")" && pwd)"
+# Requires API_KEY set to your OpenRouter token
 MODEL_MODE=api \
 API_URL=https://api.openrouter.ai/v1/chat/completions \
 API_MODEL=meta-llama/llama-3-70b-instruct \


### PR DESCRIPTION
## Summary
- emphasize that `start_llama3_70b.sh` requires an API key
- note API requirement near the jarvik-start alias section
- mention API key usage in wrapper script examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872595f3b648327b7c9108593e4377f