### PR TITLE
Add jarvik-start-70b alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ bash start_llama3_8b.sh
 
 # LLaMA 3 70B via API
 API_KEY=sk-... bash start_llama3_70b.sh  # requires your OpenRouter key
+# or using the alias
+jarvik-start-70b
 
 # Command R model
 bash start_command_r.sh

--- a/load.sh
+++ b/load.sh
@@ -19,6 +19,10 @@ alias jarvik-start-command-r='bash $DIR/start_command_r.sh'
 alias jarvik-start-api='MODEL_NAME=api bash $DIR/start_jarvik.sh'
 
 EOF
+else
+  if ! grep -q "alias jarvik-start-70b=" ~/.bashrc; then
+    echo "alias jarvik-start-70b='bash $DIR/start_llama3_70b.sh'" >> ~/.bashrc
+  fi
 fi
 
 # Načtení změn


### PR DESCRIPTION
## Summary
- ensure load.sh adds `jarvik-start-70b` alias even if aliases exist already
- document the new alias in the README example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687290dbf6448327a0154cc8b29213be